### PR TITLE
Added "Copy to clipboard" functionality

### DIFF
--- a/components/CustomFooter.vue
+++ b/components/CustomFooter.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div>
+    <div class="copy-bg sm:hidden">
       <button
         aria-label="Copy"
         v-if="
@@ -8,7 +8,7 @@
           $route.name !== 'index' &&
           $route.name !== 'about'
         "
-        class="h-6 w-6 cursor-pointer fill-current text-white mr-4 hover:text-amber copy-btn"
+        class="h-6 w-6 cursor-pointer fill-current text-white mr-4 copy-btn"
         viewBox="0 0 24 24"
         @click="handleCopy"
       >
@@ -49,10 +49,10 @@ export default {
           if (result.state == 'granted' || result.state == 'prompt') {
             navigator.clipboard.writeText(d).then(
               function () {
-                console.log("copied to clipboard")
+                console.log('copied to clipboard')
               },
               function () {
-                console.error("Unable to copy to clipboard")
+                console.error('Unable to copy to clipboard')
               }
             )
           }
@@ -65,8 +65,20 @@ export default {
 <style scoped>
 .copy-btn {
   z-index: 1;
+  margin: 12px;
   position: absolute;
-  bottom: -1;
+}
+.copy-bg {
+  z-index: 1;
+  margin-bottom: 32px;
+  margin-right: 16px;
+  position: absolute;
+  bottom: 0;
   right: 0;
+  height: 48px;
+  width: 48px;
+  border-radius: 48px;
+  border: none;
+  background-color: #ff9800;
 }
 </style>

--- a/components/CustomFooter.vue
+++ b/components/CustomFooter.vue
@@ -1,16 +1,72 @@
 <template>
-  <div
-    class="flex px-4 py-1 text-xs sm:text-base justify-between text-amber"
-    style="background: #1a1a1a; font-family: JetbrainsMono"
-  >
-    <a href="https://sphericalkat.dev"
-      ><span>© {{ new Date().getFullYear() }} SphericalKat</span></a
+  <div>
+    <div>
+      <button
+        aria-label="Copy"
+        v-if="
+          !$store.state.pastes.isEdit &&
+          $route.name !== 'index' &&
+          $route.name !== 'about'
+        "
+        class="h-6 w-6 cursor-pointer fill-current text-white mr-4 hover:text-amber copy-btn"
+        viewBox="0 0 24 24"
+        @click="handleCopy"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path d="M0 0h24v24H0z" fill="none" />
+          <path
+            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="flex px-4 py-1 text-xs sm:text-base justify-between text-amber"
+      style="background: #1a1a1a; font-family: JetbrainsMono"
     >
+      <a href="https://sphericalkat.dev"
+        ><span>© {{ new Date().getFullYear() }} SphericalKat</span></a
+      >
+    </div>
   </div>
 </template>
 
 <script>
 export default {
   name: 'CustomFooter',
+  methods: {
+    handleCopy() {
+      var d = document.getElementsByTagName('code')[0].innerHTML
+      d = d.replace(/<\/?span[^>]*>/g, '')
+      navigator.permissions
+        .query({ name: 'clipboard-write' })
+        .then((result) => {
+          if (result.state == 'granted' || result.state == 'prompt') {
+            navigator.clipboard.writeText(d).then(
+              function () {
+                console.log("copied to clipboard")
+              },
+              function () {
+                console.error("Unable to copy to clipboard")
+              }
+            )
+          }
+        })
+    },
+  },
 }
 </script>
+
+<style scoped>
+.copy-btn {
+  z-index: 1;
+  position: absolute;
+  bottom: -1;
+  right: 0;
+}
+</style>

--- a/components/CustomFooter.vue
+++ b/components/CustomFooter.vue
@@ -37,26 +37,13 @@
 </template>
 
 <script>
+import {copyToClipboard} from "~/plugins/clipboard"
+
 export default {
   name: 'CustomFooter',
   methods: {
     handleCopy() {
-      var d = document.getElementsByTagName('code')[0].innerHTML
-      d = d.replace(/<\/?span[^>]*>/g, '')
-      navigator.permissions
-        .query({ name: 'clipboard-write' })
-        .then((result) => {
-          if (result.state == 'granted' || result.state == 'prompt') {
-            navigator.clipboard.writeText(d).then(
-              function () {
-                console.log('copied to clipboard')
-              },
-              function () {
-                console.error('Unable to copy to clipboard')
-              }
-            )
-          }
-        })
+      copyToClipboard()
     },
   },
 }

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -147,10 +147,12 @@ export default {
 
   mounted() {
     document.addEventListener('keydown', this.doSave)
+    document.addEventListener('keydown', this.doCopy)
   },
 
   beforeDestroy() {
     document.removeEventListener('keydown', this.doSave)
+    document.removeEventListener('keydown', this.doCopy)
   },
 
   methods: {
@@ -188,6 +190,15 @@ export default {
 
       e.preventDefault()
       this.handleSave()
+    },
+
+    doCopy(e) {
+      if (!(e.keyCode === 67 && e.ctrlKey)) {
+        return
+      }
+
+      e.preventDefault()
+      this.handleCopy()
     },
 
     async handleSave() {

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -93,6 +93,25 @@
             d="M17.6 3.6c-.4-.4-.9-.6-1.4-.6H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V7.8c0-.5-.2-1-.6-1.4l-2.8-2.8zM12 19c-1.7 0-3-1.3-3-3s1.3-3 3-3 3 1.3 3 3-1.3 3-3 3zm1-10H7c-1.1 0-2-.9-2-2s.9-2 2-2h6c1.1 0 2 .9 2 2s-.9 2-2 2z"
           />
         </svg>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          aria-label="Copy"
+          v-if="
+            !$store.state.pastes.isEdit &&
+            $route.name !== 'index' &&
+            $route.name !== 'about'
+          "
+          class="h-6 w-6 cursor-pointer fill-current text-white hover:text-amber ml-4 copy-btn sm:hidden md:inline-block"
+          @click="handleCopy"
+        >
+          <path d="M0 0h24v24H0z" fill="none" />
+          <path
+            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+          />
+        </svg>
       </div>
     </div>
   </nav>
@@ -141,6 +160,25 @@ export default {
 
     handleEdit() {
       this.$store.commit('pastes/setIsEdit', true)
+    },
+
+    handleCopy() {
+      var d = document.getElementsByTagName('code')[0].innerHTML
+      d = d.replace(/<\/?span[^>]*>/g, '')
+      navigator.permissions
+        .query({ name: 'clipboard-write' })
+        .then((result) => {
+          if (result.state == 'granted' || result.state == 'prompt') {
+            navigator.clipboard.writeText(d).then(
+              function () {
+                console.log('copied to clipboard')
+              },
+              function () {
+                console.error('Unable to copy to clipboard')
+              }
+            )
+          }
+        })
     },
 
     doSave(e) {

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -118,6 +118,7 @@
 </template>
 
 <script>
+import {copyToClipboard} from "~/plugins/clipboard"
 const validURL = (str) => {
   const pattern = new RegExp(
     '^(https?:\\/\\/)?' + // protocol
@@ -164,25 +165,6 @@ export default {
       this.$store.commit('pastes/setIsEdit', true)
     },
 
-    handleCopy() {
-      var d = document.getElementsByTagName('code')[0].innerHTML
-      d = d.replace(/<\/?span[^>]*>/g, '')
-      navigator.permissions
-        .query({ name: 'clipboard-write' })
-        .then((result) => {
-          if (result.state == 'granted' || result.state == 'prompt') {
-            navigator.clipboard.writeText(d).then(
-              function () {
-                console.log('copied to clipboard')
-              },
-              function () {
-                console.error('Unable to copy to clipboard')
-              }
-            )
-          }
-        })
-    },
-
     doSave(e) {
       if (!(e.keyCode === 83 && e.ctrlKey)) {
         return
@@ -192,11 +174,14 @@ export default {
       this.handleSave()
     },
 
+    handleCopy(){
+      copyToClipboard()
+    },
+
     doCopy(e) {
       if (!(e.keyCode === 67 && e.ctrlKey)) {
         return
       }
-
       e.preventDefault()
       this.handleCopy()
     },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -21,7 +21,7 @@ export default {
   css: [],
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
-  plugins: [],
+  plugins: ['~/plugins/clipboard.js'],
 
   // Auto import components (https://go.nuxtjs.dev/config-components)
   components: true,

--- a/pages/_paste.vue
+++ b/pages/_paste.vue
@@ -3,6 +3,7 @@
     <Navbar />
     <code
       v-if="!$store.state.pastes.isEdit"
+      id="content"
       v-highlight="$store.state.pastes.content.content"
       class="break-word pl-4 h-full"
     ></code>

--- a/plugins/clipboard.js
+++ b/plugins/clipboard.js
@@ -1,0 +1,16 @@
+export function copyToClipboard() {
+  var d = document.getElementsByTagName('code')[0].innerHTML
+  d = d.replace(/<\/?span[^>]*>/g, '')
+  navigator.permissions.query({ name: 'clipboard-write' }).then((result) => {
+    if (result.state == 'granted' || result.state == 'prompt') {
+      navigator.clipboard.writeText(d).then(
+        function () {
+          console.log('copied to clipboard')
+        },
+        function () {
+          console.error('Unable to copy to clipboard')
+        }
+      )
+    }
+  })
+}


### PR DESCRIPTION
## What it does
* renders a button on navbar in desktop mode
* renders a FAB on mobile
* you can also press ctrl+c to copy text

## How it works
1. finds the ```<code>``` element
2. removed ```<span>``` from the innerHTML of the code tag
3. copies everything using the clipboard API (lil bit of messy "promises" there)

## Scope of improvement
* adding a snackbar to show a visual feedback