### PR TITLE
unescape html literals like <,>

### DIFF
--- a/components/CustomFooter.vue
+++ b/components/CustomFooter.vue
@@ -50,7 +50,7 @@ export default {
   name: 'CustomFooter',
   methods: {
     handleCopy() {
-      copyToClipboard()
+      copyToClipboard(this.$store)
     },
   },
 }

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -176,7 +176,7 @@ export default {
     },
 
     handleCopy() {
-      copyToClipboard()
+      copyToClipboard(this.$store)
     },
 
     doCopy(e) {

--- a/plugins/clipboard.js
+++ b/plugins/clipboard.js
@@ -1,9 +1,8 @@
-export function copyToClipboard() {
-  var d = document.getElementsByTagName('code')[0].innerHTML
-  d = d.replace(/<\/?span[^>]*>/g, '')
+export function copyToClipboard(store) {
+  const content = store.state.pastes.content.content
   navigator.permissions.query({ name: 'clipboard-write' }).then((result) => {
     if (result.state == 'granted' || result.state == 'prompt') {
-      navigator.clipboard.writeText(d).then(
+      navigator.clipboard.writeText(content).then(
         function () {
           console.log('copied to clipboard')
         },


### PR DESCRIPTION
* Changed the implementation to get content from the store
* could have also used ```unescape()```
* if this one has some bugs will revert to using the unescape function