### PR TITLE
fix(ux): moved ctrl c shortcut to alt c for copying entire paste

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -179,7 +179,7 @@ export default {
     },
 
     doCopy(e) {
-      if (!(e.keyCode === 67 && e.ctrlKey)) {
+      if (!(e.keyCode === 67 && e.altKey)) {
         return
       }
       e.preventDefault()


### PR DESCRIPTION
Changed keybinding to alt-c instead of ctrl c