### PR TITLE
fix(navbar): use URL constructor to check for URL

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -173,16 +173,12 @@
 <script>
 import { copyToClipboard } from '~/plugins/clipboard'
 const validURL = (str) => {
-  const pattern = new RegExp(
-    '^(https?:\\/\\/)?' + // protocol
-      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-      '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-      '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-      '(\\#[-a-z\\d_]*)?$',
-    'i'
-  )
-  return pattern.test(str)
+  try {
+    const url = new URL(str)
+    return true
+  } catch {
+    return false
+  }
 }
 
 export default {


### PR DESCRIPTION
This prevents the recursive regex which might choke the CPU in some cases
